### PR TITLE
Allow: providing translations for non-browser environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dist"
   ],
   "scripts": {
+    "test": "node ./test/test.mjs",
     "build": "rimraf dist && NODE_ENV=production babel src --out-dir dist --copy-files --ignore __tests__,spec.js,test.js,__snapshots__"
   },
   "devDependencies": {

--- a/src/translations.js
+++ b/src/translations.js
@@ -1,14 +1,7 @@
 let UITranslations = null;
 
-if (typeof window !== 'undefined') {
-   if (!!window.JsTranslations) {
-      UITranslations = window.JsTranslations;
-   } else {
-      const err = "UI Translations not found! Falling back to English...";
-      console.error(err);
-      const englishFallback = {};
-      UITranslations = englishFallback;
-   }
+if (typeof window !== 'undefined' && !!window.JsTranslations) {
+   UITranslations = window.JsTranslations;
 }
 
 /**
@@ -33,6 +26,8 @@ function _js(origString) {
       return 'Translated';
    }
 
+   validateTranslations();
+
    const compactedString = String(origString).replace(/\s{2,}/g, ' ');
 
    var translated = UITranslations[compactedString] || compactedString;
@@ -56,6 +51,14 @@ function ___p(number, singleString, pluralString, ...args) {
    return number === 1
       ? _js(singleString, ...args)
       : _js(pluralString, ...args);
+}
+
+function validateTranslations() {
+   if (UITranslations) {
+      return;
+   }
+   console.error("UI Translations not found! Falling back to returning the input string. Try setTranslations() or window.JsTranslations");
+   UITranslations = {};
 }
 
 export { _js, ___p, setTranslations };

--- a/src/translations.js
+++ b/src/translations.js
@@ -1,12 +1,22 @@
-var UITranslations;
+let UITranslations = null;
 
-if (!!window.JsTranslations) {
-   UITranslations = window.JsTranslations;
-} else {
-   const err = "UI Translations not found! Falling back to English...";
-   console.error(err);
-   const englishFallback = {};
-   UITranslations = englishFallback;
+if (typeof window !== 'undefined') {
+   if (!!window.JsTranslations) {
+      UITranslations = window.JsTranslations;
+   } else {
+      const err = "UI Translations not found! Falling back to English...";
+      console.error(err);
+      const englishFallback = {};
+      UITranslations = englishFallback;
+   }
+}
+
+/**
+ * Set the translation lookup directly instead of loading from
+ * window.JsTranslations
+ */
+function setTranslations(translations) {
+   UITranslations = translations;
 }
 
 /**
@@ -19,7 +29,7 @@ if (!!window.JsTranslations) {
  * won't have to localize the js file into every language when it is built.
  */
 function _js(origString) {
-   if (window.App && window.App.showTranslatedPlaceholder) {
+   if (typeof window !== 'undefined' && window.App && window.App.showTranslatedPlaceholder) {
       return 'Translated';
    }
 
@@ -48,4 +58,4 @@ function ___p(number, singleString, pluralString, ...args) {
       : _js(pluralString, ...args);
 }
 
-export { _js, ___p };
+export { _js, ___p, setTranslations };

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1,0 +1,7 @@
+import { _js, setTranslations } from "../dist/translations.js";
+import { strict as assert } from 'assert';
+
+const translatedHi = "Translated Hi (%1)";
+
+setTranslations({Hi: translatedHi});
+assert.equal("Translated Hi (param)", _js("Hi", "param"));


### PR DESCRIPTION
To support next.js, provide a setTranslations() export. Also, only complain on first use if translations aren't available.